### PR TITLE
fix: label and/or name could be empty on import

### DIFF
--- a/pkg/proji/storage/item/class.go
+++ b/pkg/proji/storage/item/class.go
@@ -56,6 +56,14 @@ func (c *Class) ImportFromConfig(configName string) error {
 
 	// Decode the file
 	_, err = toml.DecodeFile(configName, &c)
+
+	if len(c.Name) < 1 {
+		return fmt.Errorf("Name cannot be an empty string")
+	}
+	if len(c.Label) < 1 {
+		return fmt.Errorf("Label cannot be an empty string")
+	}
+
 	return err
 }
 


### PR DESCRIPTION
When importing a class from a config file the name and label fields
could be empty and proji would still import the class which obviously
could have led to problems.

Now the name and label fields are checked before the imported class is
saved. An error is returned if one of the strings is empty.

Fix #72

### Proposed Changes

-  Check the label and name fields before saving the class

