### PR TITLE
fix: bug where directories were not excluded on import

### DIFF
--- a/cmd/proji/cmd/classImport.go
+++ b/cmd/proji/cmd/classImport.go
@@ -39,10 +39,7 @@ var classImportCmd = &cobra.Command{
 
 		// Import directories
 		for _, directory := range directories {
-			if helper.IsInSlice(exclude, directory) {
-				continue
-			}
-			confName, err := importClassFromDirectory(directory, projiEnv.Svc)
+			confName, err := importClassFromDirectory(directory, exclude, projiEnv.Svc)
 			if err != nil {
 				fmt.Printf("> Import of '%s' failed: %v\n", directory, err)
 				continue
@@ -75,10 +72,10 @@ func importClassFromConfig(config string, svc storage.Service) error {
 	return svc.SaveClass(class)
 }
 
-func importClassFromDirectory(directory string, svc storage.Service) (string, error) {
+func importClassFromDirectory(directory string, excludeDir []string, svc storage.Service) (string, error) {
 	// Import class data
 	class := item.NewClass("", "", false)
-	if err := class.ImportFromDirectory(directory); err != nil {
+	if err := class.ImportFromDirectory(directory, excludeDir); err != nil {
 		return "", err
 	}
 	return class.Export()

--- a/pkg/proji/storage/item/class.go
+++ b/pkg/proji/storage/item/class.go
@@ -69,7 +69,7 @@ func (c *Class) ImportFromConfig(configName string) error {
 
 // ImportFromDirectory imports a class from a given directory. Proji will copy the
 // structure and content of the directory and create a class based on it.
-func (c *Class) ImportFromDirectory(directory string) error {
+func (c *Class) ImportFromDirectory(directory string, excludeDirs []string) error {
 	// Validate that the directory exists
 	if !helper.DoesPathExist(directory) {
 		return fmt.Errorf("Given directory does not exist")
@@ -82,7 +82,7 @@ func (c *Class) ImportFromDirectory(directory string) error {
 
 	// This map of directories that should be skipped might be moved to the main config
 	// file so that it's editable and extensible.
-	skipDirs := map[string]bool{".git": true, ".env": true}
+	excludeDirs = append(excludeDirs, []string{".git", ".env"}...)
 
 	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
 		// Skip base directory
@@ -97,7 +97,7 @@ func (c *Class) ImportFromDirectory(directory string) error {
 		// Add file or folder to class
 		if info.IsDir() {
 			c.Folders = append(c.Folders, &Folder{Destination: relPath, Template: ""})
-			if _, ok := skipDirs[info.Name()]; ok {
+			if helper.IsInSlice(excludeDirs, info.Name()) {
 				return filepath.SkipDir
 			}
 		} else {

--- a/pkg/proji/storage/item/class_test.go
+++ b/pkg/proji/storage/item/class_test.go
@@ -135,7 +135,7 @@ func TestClassImportFromDirectory(t *testing.T) {
 		}
 		defer os.RemoveAll(test.baseName)
 		c := item.NewClass("", "", false)
-		assert.NoError(t, c.ImportFromDirectory(test.baseName))
+		assert.NoError(t, c.ImportFromDirectory(test.baseName, []string{}))
 		conf, err := c.Export()
 		defer os.Remove(conf)
 		assert.NoError(t, err)


### PR DESCRIPTION
Even when the '--exclude' option was passed proji didn't ignore the
given folders.

Problem was that proji was only comparing the projects base folder name
with the excluded dirs and not the sub directories.

Now proji compares every subdirectory with the list of excluded dirs and
ignores them accordingly.

### Proposed Changes

- Fix 'class import --exlcude' not working
