### PR TITLE
feat: add version command

### DIFF
--- a/cmd/proji/cmd/version.go
+++ b/cmd/proji/cmd/version.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of proji",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("v0.18.0")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Closes #82

### Proposed Changes

- Add the command 'proji version' which prints the current version of
proji to the terminal.
