### PR TITLE
test: fix a mac specific bug in the project tests

### DIFF
--- a/pkg/proji/storage/item/project_test.go
+++ b/pkg/proji/storage/item/project_test.go
@@ -3,6 +3,7 @@ package item
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/nikoksr/proji/pkg/config"
@@ -99,7 +100,16 @@ func TestProjectCreate(t *testing.T) {
 		if err != nil {
 			t.FailNow()
 		}
-		assert.True(t, tmpDir == currentCwd)
+
+		// Special case for darwin systems.
+		// On darwin systems /tmp is a symlink to /private/tmp which gets resolved by os.Getwd().
+		// So the final path resulting from os.Getwd() differs from the original working directory
+		// by the prefixed /private.
+		if runtime.GOOS == "darwin" {
+			assert.True(t, filepath.Join("/private", tmpDir) == currentCwd)
+		} else {
+			assert.True(t, tmpDir == currentCwd)
+		}
 
 		_ = os.RemoveAll(filepath.Join(tmpDir, test.proj.Name))
 	}


### PR DESCRIPTION
Fix a mac specific bug in the project tests

On macOS the test TestProjectCreate would fail on the final assert that the user is located again in
his original working directory. The test would retrieve the cwd from os.Getwd(). Note, tests that
create files and folders are usually created in the system native temp folder. On macOS that's under
/tmp. The problem is, that /tmp is a symlink that points to /private/tmp. So, when TestProjectCreate
made the final assert that the current working directory is equal to the original working directory
os.Getwd() would return /private/tmp instead of the expected /tmp because the function resolves the
symlink. This test only failed on macOS.

Thanks to Shirley Leu (https://github.com/shirleyleu) for the bug report.