### PR TITLE
chore(cmd): add aliases and examples to packages

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -10,8 +10,9 @@ type packageCommand struct {
 
 func newPackageCommand() *packageCommand {
 	cmd := &cobra.Command{
-		Use:   "package",
-		Short: "Manage packages",
+		Use:     "package",
+		Aliases: []string{"p", "pkg"},
+		Short:   "Manage packages",
 	}
 
 	cmd.AddCommand(

--- a/cmd/packageAdd.go
+++ b/cmd/packageAdd.go
@@ -23,6 +23,7 @@ func newPackageAddCommand() *packageAddCommand {
 		Short:                 "Add one or more packages",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(1),
+		Aliases:               []string{"a"},
 		Deprecated:            "command 'package add' will be deprecated in the next release",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for _, name := range args {

--- a/cmd/packageExport.go
+++ b/cmd/packageExport.go
@@ -21,8 +21,9 @@ func newPackageExportCommand() *packageExportCommand {
 	var destination string
 
 	cmd := &cobra.Command{
-		Use:   "export LABEL [LABEL...]",
-		Short: "Export one or more packages",
+		Use:     "export LABEL [LABEL...]",
+		Short:   "Export one or more packages",
+		Aliases: []string{"e"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if exportAll && template {
 				return fmt.Errorf("the flags 'template' and 'all' cannot be used at the same time")

--- a/cmd/packageImport.go
+++ b/cmd/packageImport.go
@@ -29,8 +29,12 @@ func newPackageImportCommand() *packageImportCommand {
 	var remoteRepos, directories, configs, packages, collections []string
 
 	cmd := &cobra.Command{
-		Use:   "import LOCATION [LOCATION...]",
-		Short: "Import one or more packages",
+		Use:     "import FROM [FROM...]",
+		Short:   "Import one or more packages",
+		Aliases: []string{"i"},
+		Example: `  proji package import gh:nikoksr/proji-official-collection/configs/nikoksr/go.toml
+  proji package import -r https://github.com/torvalds/linux
+  proji package import -d .`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().NFlag() == 0 {
 				if len(args) < 1 {

--- a/cmd/packageLs.go
+++ b/cmd/packageLs.go
@@ -17,6 +17,7 @@ func newPackageListCommand() *packageListCommand {
 	cmd := &cobra.Command{
 		Use:                   "ls",
 		Short:                 "List packages",
+		Aliases:               []string{"l"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/packageRm.go
+++ b/cmd/packageRm.go
@@ -17,8 +17,9 @@ func newPackageRemoveCommand() *packageRemoveCommand {
 	var removeAllPackages, forceRemovePackages bool
 
 	cmd := &cobra.Command{
-		Use:   "rm LABEL [LABEL...]",
-		Short: "Remove one or more packages",
+		Use:     "rm LABEL [LABEL...]",
+		Short:   "Remove one or more packages",
+		Aliases: []string{"r"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Collect packages that will be removed
 			var err error

--- a/cmd/packageShow.go
+++ b/cmd/packageShow.go
@@ -22,8 +22,9 @@ func newPackageShowCommand() *packageShowCommand {
 	var showAll bool
 
 	cmd := &cobra.Command{
-		Use:   "show LABEL [LABEL...]",
-		Short: "Show details about one or more packages",
+		Use:     "show LABEL [LABEL...]",
+		Short:   "Show details about one or more packages",
+		Aliases: []string{"s"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !showAll && len(args) < 1 {
 				return fmt.Errorf("missing package label")

--- a/cmd/projectAdd.go
+++ b/cmd/projectAdd.go
@@ -22,6 +22,7 @@ func newProjectAddCommand() *projectAddCommand {
 	cmd := &cobra.Command{
 		Use:                   "add LABEL PATH",
 		Short:                 "Add an existing project",
+		Aliases:               []string{"a"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/projectClean.go
+++ b/cmd/projectClean.go
@@ -15,6 +15,7 @@ func newProjectCleanCommand() *projectCleanCommand {
 	cmd := &cobra.Command{
 		Use:                   "clean",
 		Short:                 "Clean up projects",
+		Aliases:               []string{"cln"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/projectCreate.go
+++ b/cmd/projectCreate.go
@@ -23,6 +23,7 @@ func newProjectCreateCommand() *projectCreateCommand {
 	cmd := &cobra.Command{
 		Use:                   "create LABEL NAME [NAME...]",
 		Short:                 "Create one or more projects",
+		Aliases:               []string{"c"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/projectLs.go
+++ b/cmd/projectLs.go
@@ -18,6 +18,7 @@ func newProjectListCommand() *projectListCommand {
 	cmd := &cobra.Command{
 		Use:                   "ls",
 		Short:                 "List projects",
+		Aliases:               []string{"l"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/projectRm.go
+++ b/cmd/projectRm.go
@@ -19,8 +19,9 @@ func newProjectRemoveCommand() *projectRemoveCommand {
 	var removeAllProjects, forceRemoveProjects bool
 
 	cmd := &cobra.Command{
-		Use:   "rm PATH [PATH...]",
-		Short: "Remove one or more projects",
+		Use:     "rm PATH [PATH...]",
+		Short:   "Remove one or more projects",
+		Aliases: []string{"r"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Collect projects that will be removed
 			var projects []*domain.Project

--- a/cmd/projectSet.go
+++ b/cmd/projectSet.go
@@ -10,8 +10,9 @@ type projectSetCommand struct {
 
 func newProjectSetCommand() *projectSetCommand {
 	cmd := &cobra.Command{
-		Use:   "set",
-		Short: "Set project information",
+		Use:     "set",
+		Short:   "Set project information",
+		Aliases: []string{"s"},
 	}
 
 	cmd.AddCommand(newProjectSetPathCommand().cmd)

--- a/cmd/projectSetPath.go
+++ b/cmd/projectSetPath.go
@@ -17,6 +17,7 @@ func newProjectSetPathCommand() *projectSetPath {
 	cmd := &cobra.Command{
 		Use:                   "path OLD-PATH NEW-PATH",
 		Short:                 "Set a new path",
+		Aliases:               []string{"p"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ func newVersionCommand() *versionCommand {
 	cmd := &cobra.Command{
 		Use:                   "version",
 		Short:                 "Print the version",
+		Aliases:               []string{"v"},
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
### Summary

Add aliases and examples to commands.

### Proposed Changes

-   Add command aliases (e.g. `proji package import` can be written as `proji p i`)
-   Add example to `package import`

### Resolved Issues

Closes #139 