### PR TITLE
fix(cmd): typo in string format

### DIFF
--- a/cmd/projectCreate.go
+++ b/cmd/projectCreate.go
@@ -54,7 +54,7 @@ func newProjectCreateCommand() *projectCreateCommand {
 				}
 
 				// Print error message
-				message.Warningf("failed to create project, %s", projectName, err.Error())
+				message.Warningf("failed to create project, %s, %s", projectName, err.Error())
 
 				// Check if error is because of a project is already associated with this path. Continue loop if so.
 				if errors.Is(err, projectstore.ErrProjectExists) {


### PR DESCRIPTION
### Resolved Issues

Fixes `%!(EXTRA string=create project: mkdir : no such file or directory)> Do you want to replace it? [y/N]`