### PR TITLE
refactor(remote): improve setting of branch of github repos

### DIFF
--- a/pkg/remote/github/repo.go
+++ b/pkg/remote/github/repo.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	gh "github.com/google/go-github/v31/github"
@@ -17,22 +18,71 @@ type repo struct {
 	client *gh.Client
 }
 
-// setRepoSHA sets the repoSHA attribute equal to the SHA-1 of the last commit in the current branch.
-func (r *repo) setSHA(ctx context.Context) error {
-	if r.branch == "" {
-		/*
-			r := &gh.Repository{}
-			r, _, err := g.client.Repositories.Get(ctx, g.OwnerName, g.RepoName)
-			if err != nil {
-				return err
-			}
-			g.BranchName = r.GetDefaultBranch()
-		*/
-		// Default to master branch for now. The above uses too many API calls and Github's API limit gets exceeded
-		// too quickly.
-		r.branch = "master"
+func (r *repo) setBranch(ctx context.Context, isAuthenticated bool) error {
+	// Skip if a branch was already set
+	if r.branch != "" {
+		return nil
 	}
 
+	// Only do this if the user is authenticated to github otherwise this would fill up your rate limit to quickly.
+	if isAuthenticated {
+		// Get an instance of our github repo directly from the github api library
+		ghRepo, response, err := r.client.Repositories.Get(ctx, r.owner, r.name)
+		if err != nil {
+			return err
+		}
+
+		// Validate the response
+		err = gh.CheckResponse(response.Response)
+		if err != nil {
+			return err
+		}
+
+		// Try to get the repo's default branch
+		r.branch = ghRepo.GetDefaultBranch()
+		if r.branch == "" {
+			return fmt.Errorf("failed to load the default branch for the repository")
+		}
+	}
+
+	// Just try the two default branches - master being the old and main the new default branch of new repos on gh.
+	// Yes, I know it would probably be more efficient at this point in time to test the master branch first since
+	// many older repos use that as their default, but since I support github's change of the default branch name and
+	// the distribution will shift more towards the main branch in the future anyway, we'll test the main branch first
+	// here. We're not wasting any api calls here.
+	branches := []string{"main", "master"}
+	for _, branch := range branches {
+		doesExist, err := doesBranchExist(r.owner, r.name, branch)
+		if err != nil {
+			return err
+		}
+		if doesExist {
+			r.branch = branch
+			break
+		}
+	}
+
+	return nil
+}
+
+// doesBranchExist checks if the branch of a repository exists by checking the http get return code of the repo url
+// including the branch name.
+func doesBranchExist(owner, repo, branch string) (bool, error) {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s/tree/%s", owner, repo, branch)
+	resp, err := http.Get(repoURL)
+	if err != nil {
+		return false, err
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// setRepoSHA sets the repoSHA attribute equal to the SHA-1 of the last commit in the current branch.
+func (r *repo) setSHA(ctx context.Context) error {
 	branch, _, err := r.client.Repositories.GetBranch(ctx, r.owner, r.name, r.branch)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
Branch will now be set automatically to the repos default branch if the
proji user has provided a github token. If no token was given proji now
will check for the availability of a main branch first and on failure
check for a master branch.

Short summary of what the pull request changes.

### Proposed Changes

-   Create separate setBranch function
-   Set branch to default branch through GH api if token was provided
-   Set branch to `main` or `master` if no token was given

### Resolved Issues

Closes #203 